### PR TITLE
Dup addremark bugfix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/InternshipDeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InternshipDeleteTaskCommand.java
@@ -60,6 +60,9 @@ public class InternshipDeleteTaskCommand extends InternshipCommand {
         Task taskToDelete = internshipToDeleteTask.getTaskList().getTask(taskIndex.getZeroBased());
         internshipToDeleteTask.getTaskList().deleteTask(taskIndex.getZeroBased());
 
+        // This is necessary to trigger the UI to update the displayed deadline
+        model.setInternship(internshipToDeleteTask, internshipToDeleteTask);
+
         model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
 
         return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS, taskToDelete));

--- a/src/main/java/seedu/address/logic/parser/InternshipAddDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InternshipAddDeadlineCommandParser.java
@@ -55,6 +55,8 @@ public class InternshipAddDeadlineCommandParser implements InternshipParser<Inte
                     Deadline.MESSAGE_CONSTRAINTS), pe);
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SELECT_TASK, PREFIX_DEADLINE);
+
         return new InternshipAddDeadlineCommand(internshipIndex, taskIndex, deadline);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/InternshipAddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InternshipAddTaskCommandParser.java
@@ -45,6 +45,8 @@ public class InternshipAddTaskCommandParser implements InternshipParser<Internsh
                     InternshipAddTaskCommand.MESSAGE_EMPTY_TASK), pe);
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TASK);
+
         return new InternshipAddTaskCommand(index, task);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/InternshipFindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InternshipFindCommandParser.java
@@ -47,6 +47,8 @@ public class InternshipFindCommandParser implements InternshipParser<InternshipF
             throw new ParseException(InternshipFindCommand.INVALID_MODE_SPECIFIED);
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(InternshipFindCommandParser.supportedPrefixes);
+
         return new InternshipFindCommand(createPredicate(mode, argMultimap));
     }
 

--- a/src/main/java/seedu/address/logic/parser/InternshipRemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InternshipRemarkCommandParser.java
@@ -40,6 +40,8 @@ public class InternshipRemarkCommandParser {
 
         remark = InternshipParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get());
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_REMARK);
+
         return new InternshipRemarkCommand(index, remark);
     }
 }


### PR DESCRIPTION
Fixed bug where commands with duplicate prefixes still worked:
- InternshipAddDeadlineCommand
- InternshipAddTaskCommandParser
- InternshipDeleteTaskCommandParser
- InternshipFindCommandParser
- InternshipRemarkCommandParser

Fixed bug where task deletion was not immediately reflected in UI
