### PR TITLE
Fix Incorrect Delete Command Error Messages

### DIFF
--- a/src/main/java/seedu/address/logic/parser/InternshipDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InternshipDeleteCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.InternshipMessages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.InternshipMessages.MESSAGE_INVALID_INTERNSHIP_DISPLAYED_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.InternshipDeleteCommand;
@@ -10,20 +12,23 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new InternshipDeleteCommand object
  */
 public class InternshipDeleteCommandParser implements InternshipParser<InternshipDeleteCommand> {
-
-    /**
-     * Parses the given {@code String} of arguments in the context of the InternshipDeleteCommand
-     * and returns a InternshipDeleteCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
-     */
-
     public InternshipDeleteCommand parse(String args) throws ParseException {
-        try {
-            Index index = InternshipParserUtil.parseIndex(args);
-            return new InternshipDeleteCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, InternshipDeleteCommand.MESSAGE_USAGE), pe);
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+
+        Index index;
+
+        if (argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    InternshipDeleteCommand.MESSAGE_USAGE));
         }
+
+        try {
+            index = InternshipParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(MESSAGE_INVALID_INTERNSHIP_DISPLAYED_INDEX, pe);
+        }
+
+        return new InternshipDeleteCommand(index);
     }
 }


### PR DESCRIPTION
Fixed the incorrect error messages for delete string and delete <index> where index is 0 or negative

![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/120201372/8297d77a-301f-471b-9845-72ff1196ec08)

![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/120201372/79a0f933-ced5-4a6c-9682-abf11c61745d)

![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/120201372/da525b5b-58f5-4266-ba5d-ef24ea5c2737)


