### PR TITLE
Update supported prefixes find

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -565,6 +565,8 @@ This will filter the list of internships to show you only those with both status
    Supported prefixes are /com, /poc, /loc, /status, /desc, /role, /remark`<br>
 2. Make sure you specify the MODE of search, which must be either `withall` or `withany`. If not, the command will be rejected with error message:<br>
 `Invalid mode specified. Please specify either 'withall' or 'withany'.`<br>
+3. Just to note, the unsupported fields in this version are `/phone`, `/email`, `/task`, `/selecttask` and `/deadline`.<br>
+Searching for these fields will result in an error message, highlighting the unsupported fields explicitly.
 </div>
 
 [Go to Field Summary](#field-summary) | [Go to Command Summary](#command-summary) | [Go to Table of Contents](#table-of-contents)

--- a/src/main/java/seedu/address/logic/commands/InternshipFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InternshipFindCommand.java
@@ -9,9 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.InternshipMessages;
 import seedu.address.logic.parser.InternshipFindCommandParser;
@@ -48,12 +45,13 @@ public class InternshipFindCommand extends InternshipCommand {
             + PREFIX_COMPANY + " Tiktok Google " + PREFIX_STATUS + " accepted";
     public static final String NO_SEARCH_KEY_SPECIFIED = "At least one supported field prefix and keyword "
             + "must be specified to be searched.\nSupported prefixes are "
-            + Arrays.stream(InternshipFindCommandParser.getSupportedPrefixes())
-                    .map(Prefix::toString).collect(Collectors.joining(", "));
+            + Prefix.getPrefixesAsString(", ", InternshipFindCommandParser.getSupportedPrefixes());
+    public static final String UNSUPPORTED_PREFIX_SPECIFIED = "Unsupported field prefix specified: %s\n"
+            + "Please specify only supported prefixes.\nSupported prefixes are "
+            + Prefix.getPrefixesAsString(", ", InternshipFindCommandParser.getSupportedPrefixes());
     public static final String INVALID_MODE_SPECIFIED = "Invalid mode specified. "
             + "Please specify either 'withall' or 'withany'.";
     public static final String NO_KEYWORD_SPECIFIED = "At least one keyword must be specified for each field prefix.";
-
     private final InternshipContainsKeywordsPredicate predicate;
 
     public InternshipFindCommand(InternshipContainsKeywordsPredicate predicate) {

--- a/src/main/java/seedu/address/logic/parser/InternshipFindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InternshipFindCommandParser.java
@@ -5,15 +5,21 @@ import static seedu.address.logic.InternshipMessages.MESSAGE_INVALID_COMMAND_FOR
 import static seedu.address.logic.commands.InternshipFindCommand.MODE_WITHALL;
 import static seedu.address.logic.commands.InternshipFindCommand.MODE_WITHANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SELECT_TASK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
 import static seedu.address.logic.parser.InternshipParserUtil.anyPrefixesPresent;
 import static seedu.address.logic.parser.InternshipParserUtil.prefixesPresentAreNotEmpty;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import seedu.address.logic.commands.InternshipFindCommand;
@@ -26,6 +32,10 @@ import seedu.address.model.internship.InternshipContainsKeywordsPredicate;
 public class InternshipFindCommandParser implements InternshipParser<InternshipFindCommand> {
     private static final Prefix[] supportedPrefixes = {PREFIX_COMPANY, PREFIX_CONTACT_NAME, PREFIX_LOCATION,
         PREFIX_STATUS, PREFIX_DESCRIPTION, PREFIX_ROLE, PREFIX_REMARK};
+
+    private static final Prefix[] unsupportedPrefixes = {PREFIX_CONTACT_EMAIL,
+        PREFIX_CONTACT_NUMBER, PREFIX_SELECT_TASK, PREFIX_TASK, PREFIX_DEADLINE};
+
     /**
      * Parses the given {@code String} of arguments in the context of the InternshipFindCommand
      * and returns a InternshipFindCommand object for execution.
@@ -39,6 +49,17 @@ public class InternshipFindCommandParser implements InternshipParser<InternshipF
         }
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, InternshipFindCommandParser.supportedPrefixes);
+
+        ArgumentMultimap unsupportedArgMultimap =
+                ArgumentTokenizer.tokenize(args, InternshipFindCommandParser.unsupportedPrefixes);
+
+        if (anyPrefixesPresent(unsupportedArgMultimap, InternshipFindCommandParser.unsupportedPrefixes)) {
+            Prefix[] unsupportedPrefixesPresent =
+                    getPrefixesPresent(unsupportedArgMultimap, InternshipFindCommandParser.unsupportedPrefixes);
+
+            throw new ParseException(String.format(InternshipFindCommand.UNSUPPORTED_PREFIX_SPECIFIED,
+                    Prefix.getPrefixesAsString(", ", unsupportedPrefixesPresent)));
+        }
 
         if (!anyPrefixesPresent(argMultimap, InternshipFindCommandParser.supportedPrefixes)) {
             throw new ParseException(InternshipFindCommand.NO_SEARCH_KEY_SPECIFIED);
@@ -80,5 +101,13 @@ public class InternshipFindCommandParser implements InternshipParser<InternshipF
      */
     public static Prefix[] getSupportedPrefixes() {
         return supportedPrefixes.clone();
+    }
+
+    /**
+     * @return an array of the prefixes from {@code prefixes} that are present in the given {@code ArgumentMultimap}
+     */
+    protected static Prefix[] getPrefixesPresent(ArgumentMultimap argMultimap, Prefix[] prefixes) {
+        return Arrays.stream(prefixes).filter(prefix -> argMultimap.getValue(prefix).isPresent())
+                .toArray(Prefix[]::new);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -1,8 +1,10 @@
 package seedu.address.logic.parser;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 /**
  * A prefix that marks the beginning of an argument in an arguments string.
- * E.g. 't/' in 'add James t/ friend'.
  */
 public class Prefix {
     private final String prefix;
@@ -23,6 +25,12 @@ public class Prefix {
     @Override
     public int hashCode() {
         return prefix == null ? 0 : prefix.hashCode();
+    }
+
+    public static String getPrefixesAsString(String delimiter, Prefix[] prefixes) {
+        return Arrays.stream(prefixes)
+                .map(Prefix::toString)
+                .collect(Collectors.joining(delimiter));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/InternshipFindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/InternshipFindCommandParserTest.java
@@ -1,8 +1,10 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.InternshipMessages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.InternshipFindCommand.MODE_WITHALL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
 import static seedu.address.logic.parser.InternshipCommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.InternshipCommandParserTestUtil.assertParseSuccess;
 
@@ -34,7 +36,7 @@ public class InternshipFindCommandParserTest {
     }
 
     @Test
-    public void parse_unsupportedPrefix_throwsParseException() {
+    public void parse_invalidPrefix_throwsParseException() {
         assertParseFailure(parser, MODE_WITHALL + " /invalidPrefix Microsoft Google",
                 String.format(InternshipFindCommand.NO_SEARCH_KEY_SPECIFIED));
     }
@@ -63,5 +65,35 @@ public class InternshipFindCommandParserTest {
         // multiple whitespaces between keywords
         assertParseSuccess(parser, MODE_WITHALL + " "
                 + PREFIX_COMPANY + " \n Microsoft \n \t Google  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_unsupportedPrefix_throwsParseException() {
+        // EP: Single unsupported prefix
+        assertParseFailure(parser, MODE_WITHALL + " /phone 99999999",
+                String.format(InternshipFindCommand.UNSUPPORTED_PREFIX_SPECIFIED, "/phone"));
+
+        // EP: Multiple unsupported prefixes
+        assertParseFailure(parser, MODE_WITHALL + " /phone 99999999 /email helloworld@gmail.com",
+                String.format(InternshipFindCommand.UNSUPPORTED_PREFIX_SPECIFIED, "/email, /phone"));
+
+        // EP: Multiple unsupported prefixes with supported prefix
+        assertParseFailure(parser, MODE_WITHALL + " /selecttask 2 /phone 99999999 /com Microsoft Google",
+                String.format(InternshipFindCommand.UNSUPPORTED_PREFIX_SPECIFIED, "/phone, /selecttask"));
+    }
+    @Test
+    public void getPrefixesPresent() {
+        // EP: Prefixes present
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize("withall /com Microsoft Google", PREFIX_COMPANY);
+        Prefix[] prefixesPresent = InternshipFindCommandParser.getPrefixesPresent(argMultimap, new Prefix[]{PREFIX_COMPANY});
+        assertEquals(1, prefixesPresent.length);
+        assertEquals(PREFIX_COMPANY, prefixesPresent[0]);
+
+        // EP: Prefixes not present
+        argMultimap = ArgumentTokenizer.tokenize("withall /com Microsoft Google", PREFIX_COMPANY);
+        prefixesPresent = InternshipFindCommandParser
+                .getPrefixesPresent(argMultimap, new Prefix[]{PREFIX_CONTACT_EMAIL});
+        assertEquals(0, prefixesPresent.length);
+
     }
 }

--- a/src/test/java/seedu/address/logic/parser/InternshipFindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/InternshipFindCommandParserTest.java
@@ -85,7 +85,8 @@ public class InternshipFindCommandParserTest {
     public void getPrefixesPresent() {
         // EP: Prefixes present
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize("withall /com Microsoft Google", PREFIX_COMPANY);
-        Prefix[] prefixesPresent = InternshipFindCommandParser.getPrefixesPresent(argMultimap, new Prefix[]{PREFIX_COMPANY});
+        Prefix[] prefixesPresent = InternshipFindCommandParser
+                .getPrefixesPresent(argMultimap, new Prefix[]{PREFIX_COMPANY});
         assertEquals(1, prefixesPresent.length);
         assertEquals(PREFIX_COMPANY, prefixesPresent[0]);
 

--- a/src/test/java/seedu/address/logic/parser/PrefixTest.java
+++ b/src/test/java/seedu/address/logic/parser/PrefixTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+
+import org.junit.jupiter.api.Test;
+
+class PrefixTest {
+    @Test
+    void getPrefixesAsString() {
+        // EP: Empty Prefix[]
+        Prefix[] emptyPrefixes = new Prefix[]{};
+        assertEquals("", Prefix.getPrefixesAsString(", ", emptyPrefixes));
+
+        // EP: Single Prefix
+        Prefix[] singlePrefixes = new Prefix[]{PREFIX_COMPANY};
+        assertEquals("/com", Prefix.getPrefixesAsString(", ", singlePrefixes));
+
+        // EP: Multiple Prefixes
+        Prefix[] multiplePrefixes = new Prefix[]{PREFIX_COMPANY, PREFIX_CONTACT_NAME, PREFIX_LOCATION};
+        assertEquals("/com, /poc, /loc", Prefix.getPrefixesAsString(", ", multiplePrefixes));
+    }
+}


### PR DESCRIPTION
 Add check for unsupported prefixes

Currently, find command only shows the supported prefixes
recognised by CareerSync. However, it does not explicitly
highlight to the users which of the prefixes (that are recognised
by our ArgumentMultiMap) are unsupported etc. /email, /phone.

Let's
* Make explicit the unsupported fields keyed in by the user.

## Some visual testing

```find withall /status accepted /phone 999```

![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/96646939/f74ed798-ac29-4e77-bcab-b8a5a579b957)

```find withall /status accepted /phone 999 /task sweep /deadline 20/04/2020```

![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/96646939/a409d2c2-4eb4-49d1-be61-87e1567bd1dd)

### Using withany

```find withany /task 2 /com Facesoft```

![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/96646939/adc2636c-5a1c-4280-ac5c-2fec0d272ea1)

### Without any mode specified, it still shows the unsupported field error first

```find /phone 999```

![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/96646939/c48a0f5a-1387-4d28-9578-865ddfd6159f)





