### PR TITLE
Rewrite find command description to match intended behaviour

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -578,7 +578,10 @@ This will filter the list of internships to show you only those with both status
 </div>
 
 <div markdown="span" class="alert alert-info">
-ℹ️ **Tip:** If you want to view all internships again, simply use the [list](#listing-all-internships-list) command.
+ℹ️ **Tip:** 
+<br>
+1. If you want to view all internships again, simply use the [list](#listing-all-internships-list) command.<br>
+2. Upon executing commands, with the exception of `find`, `delete`, `sort`, `clear`, `help` and `exit`, the filter will be removed i.e. the list will be reset to show all internships.
 </div>
 
 <div markdown="span" class="alert alert-danger">

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -540,7 +540,7 @@ This sets the remark of the internship at index 1 to be `This internship has a b
 
 #### Finding internships by keywords: `find`
 
-You can use this to filter the visible internships in CareerSync by keywords.
+You can use this to filter what internships you see in CareerSync based on the keywords you provide.
 
 **Format:** `find MODE [/com COMPANY_NAME_KEYWORDS] [/poc CONTACT_NAME_KEYWORDS] [/loc LOCATION_KEYWORDS] [/status STATUS_KEYWORDS] [/desc DESCRIPTION_KEYWORDS] [/role ROLE_KEYWORDS] [/remark REMARK_KEYWORDS]`
 
@@ -553,6 +553,12 @@ You can use this to filter the visible internships in CareerSync by keywords.
 * Only full words will be matched e.g. `Goo` will not match `Google`
 * Internship matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `Hewlett Song` will return `Hewlett Packard`, `Song Fa`
+
+<div markdown="span" class="alert alert-danger">
+
+⚠️ **Caution**:
+Do note that if you apply successive find commands do not compound the filters. Only your most recent find command will be applied.
+</div>
 
 <div markdown="span" class="alert alert-success">
 
@@ -732,7 +738,7 @@ This clears all your internship entries from CareerSync.
 
 <div markdown="span" class="alert alert-danger">
 
-⚠️ Caution:
+⚠️ **Caution**:
 This operation is irreversible. Once you clear all entries, you cannot undo it.
 </div>
 
@@ -767,7 +773,7 @@ Format: `exit`
 
 <div markdown="span" class="alert alert-danger">
 
-⚠️ Caution:
+⚠️ **Caution**:
 Users are **NOT** recommended to modify their data file directly, since wrong formatting will cause the app to malfunction.
 Only do so if you are an experienced user! <br>
 </div>


### PR DESCRIPTION
Resolves #230
Addresses #226 but still needs further work on DG 
===

-------------
The find command description currently includes a misleading line that leads users to believe that its effects can be stacked.

Let's
* Remove this misleading line
* Add a caution explicitly specifiying that successive find commands do not stack

-------------
Add tip describing filter reset upon execution of commands

Our current implement of model that sets the predicate to
show all internships upon execution of most commands causes
the find filter to be reset every time a command is executed.

There are a few exceptions like delete, sort etc. that are also
highlighted in this change.

Let's
* Make explicit this behaviour in the UG.

For future reference
* This feature will be under our planned enhancements.