### PR TITLE
Increase visibility of caution message for copy pasting commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -170,6 +170,13 @@ For the restrictions on what is accepted for each field, kindly refer to [Fields
 ### Tutorial
 This section would guide you through the basic commands of <span style="color: #f66a0a;">CareerSync</span>, and how to use them.
 
+<div markdown="span" class="alert alert-danger">
+
+⚠️ **Caution**:
+If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines
+as space characters surrounding line-breaks may be omitted when copied over to the application.
+</div>
+
 #### Clear sample internship entries: `clear`
 
 To begin using <span style="color: #f66a0a;">CareerSync</span>, you should clear the sample internship entries that are present when you first start the 
@@ -321,6 +328,13 @@ ________________________________________________________________________________
 
 Let's do a quick review of the commands!
 
+<div markdown="span" class="alert alert-danger">
+
+⚠️ **Caution**:
+If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines 
+as space characters surrounding line-breaks may be omitted when copied over to the application.
+</div>
+
 #### Command Summary
 
 | Action                                         | Description                              | Format                                                                                                                                                                                                |
@@ -352,8 +366,6 @@ the displayed internship indexes.
 * Parameters can be in any order.<br>
   e.g. if the command specifies `/com COMPANY_NAME /desc DESCRIPTION`, `/desc DESCRIPTION /com COMPANY_NAME` is also acceptable.
 
-* If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines
-  as space characters surrounding line-breaks may be omitted when copied over to the application.
 </div>
 
 #### Viewing help: `help`


### PR DESCRIPTION
Resolves #224 
=
## How it tackles the above issue:
The actual command in our UG on the web page works fine, but the exported PDF version breaks the whitespacing around line breaks, which causes the words in our command to become connected, causing a failure to detect keywords.

## Commit notes
Currently, there is a warning to users about copy pasting commands directly from the PDF version of the UG under the 'Notes about command format' section.
![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/96646939/67ca48fc-8631-4232-b20e-969f1dd4ee29)

This is not very visible to users as it is the 4th bullet point and is likely to be skipped through.

## Solutions implemented in this PR
* Improve it's visibility by wrapping in a 'Caution' formatting
* Place it at the beginning in 2 places, under `Tutorial` and `Commands` sections since these are the places where the user is most likely to copy paste commands.

![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/96646939/3859ecd5-560a-4902-991b-ad0163ee275f)
![image](https://github.com/AY2324S2-CS2103T-W11-1/tp/assets/96646939/1a7c16d8-1016-46cf-99a4-29e1e8a93489)
