### PR TITLE
Fix null invocation bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/InternshipEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InternshipEditCommand.java
@@ -83,7 +83,8 @@ public class InternshipEditCommand extends InternshipCommand {
         requireNonNull(model);
         List<Internship> lastShownList = model.getFilteredInternshipList();
         // This is the internship being displayed by the UI.
-        Internship currentSelectedInternship = model.getSelectedInternship().get(0);
+        Internship currentSelectedInternship = model.getSelectedInternship().isEmpty() ? null
+                : model.getSelectedInternship().get(0);
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(InternshipMessages.MESSAGE_INVALID_INTERNSHIP_DISPLAYED_INDEX);
@@ -91,7 +92,8 @@ public class InternshipEditCommand extends InternshipCommand {
 
         Internship internshipToEdit = lastShownList.get(index.getZeroBased());
 
-        boolean isCurrentSelectedInternshipBeingEdited = currentSelectedInternship.equals(internshipToEdit);
+        // .equals() handles nulls check
+        boolean isCurrentSelectedInternshipBeingEdited = internshipToEdit.equals(currentSelectedInternship);
 
         Internship editedInternship = createEditedInternship(internshipToEdit, editInternshipDescriptor);
 

--- a/src/main/java/seedu/address/model/InternshipModelManager.java
+++ b/src/main/java/seedu/address/model/InternshipModelManager.java
@@ -42,7 +42,7 @@ public class InternshipModelManager implements InternshipModel {
         this.userPrefs = new InternshipUserPrefs(userPrefs);
         filteredInternships = new FilteredList<>(this.internshipData.getInternshipList());
         sortedInternships = new SortedList<>(filteredInternships);
-        selectedInternship = new FilteredList<>(this.internshipData.getInternshipList());
+        selectedInternship = new FilteredList<>(filteredInternships);
     }
 
     public InternshipModelManager() {


### PR DESCRIPTION
## Resolves #247 
By the way, the explanation given in that Issue is not exactly correct, so refer to below for a better understanding.
The issue happens even without editing to the similar internship, as long as the steps are followed.

Explanation of this bug:
This was created during the pull #197 . This added a check for the current user selected internship, which ASSUMES that there would be an internship selected (defaulted to first internship in list).

This is true when the app is just launched with sample data. However when the data is cleared, there would be 0 internships and thus the selected internship will not exist as well.

This culminates in an IndexOutOfBoundsException when checking for the current selected internship during check while executing edit.

Our regression testing did not catch this case.

Changes:
Add an isEmpty() check before .get().